### PR TITLE
No default secret key in Workflow

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -19,5 +19,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Build with Maven
         run: mvn -f Validator/pom.xml --batch-mode --update-snapshots verify

--- a/Validator/pom.xml
+++ b/Validator/pom.xml
@@ -90,7 +90,7 @@
         <executions>
           <execution>
             <id>sign-artifacts</id>
-            <phase>verify</phase>
+            <phase>deploy</phase>
             <goals>
               <goal>sign</goal>
             </goals>


### PR DESCRIPTION
Verifying the project includes trying to package and sign the project, therefore the Key for signing needs to be imported into the workflow